### PR TITLE
chore(deps): cap dependency versions

### DIFF
--- a/git_httpsable-push.gemspec
+++ b/git_httpsable-push.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'thor'
-  spec.add_runtime_dependency 'git'
-  spec.add_runtime_dependency 'git_clone_url'
+  spec.add_runtime_dependency 'thor', '>= 0.19', '< 1.0'
+  spec.add_runtime_dependency 'git', '>= 1.0', '< 2.0'
+  spec.add_runtime_dependency 'git_clone_url', '>= 1.0', '< 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
`uri-ssh_git` and `git_clone_url` will change api.
https://github.com/packsaddle/ruby-uri-ssh_git/issues/14
https://github.com/packsaddle/ruby-git_clone_url/issues/6
